### PR TITLE
improve task ls filtering and type-safe CLI parsing

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,6 +3,7 @@
 //! All commands and subcommands are declared here using clap's derive macros.
 //! Parsed values flow into [`crate::dispatch`] for execution.
 
+use crate::models::{Priority, Status};
 use clap::{Parser, Subcommand};
 
 /// Root CLI entry point for `rtodo`.
@@ -64,8 +65,8 @@ pub enum TaskCommands {
     /// `--parent` adds this as a subtask of the given task ID (max depth: 2).
     Add {
         desc: String,
-        #[arg(short, long, default_value_t = String::from("medium"))]
-        priority: String,
+        #[arg(short, long, default_value_t = Priority::Medium)]
+        priority: Priority,
         #[arg(short = 'P', long)]
         parent: Option<u32>,
     },
@@ -76,7 +77,7 @@ pub enum TaskCommands {
     /// Use `--pending` / `-p` to show only incomplete tasks (new + in-progress).
     Ls {
         /// Filter by status: new, in-progress, completed
-        status: Option<String>,
+        status: Option<Status>,
 
         /// Show only incomplete tasks (new + in-progress)
         #[arg(short, long, conflicts_with = "status")]
@@ -89,15 +90,14 @@ pub enum TaskCommands {
     Start { tid: u32 },
 
     /// Mark the task as completed. Defaults to active task
-    /// 
+    ///
     /// --tid defaults to active task
     Complete { tid: Option<u32> },
 
     /// Move a task to a specific status by its ID.
     ///
     /// --tid defaults to active task
-    /// `status` accepts: `new`, `in_progress`, `completed`.
-    Move { tid: Option<u32>, status: String },
+    Move { tid: Option<u32>, status: Status },
 
     /// Delete a task by its ID.
     Delete { tid: u32 },
@@ -112,6 +112,6 @@ pub enum TaskCommands {
         #[arg(short, long)]
         desc: Option<String>,
         #[arg(short, long)]
-        priority: Option<String>,
+        priority: Option<Priority>,
     },
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -82,21 +82,26 @@ pub enum TaskCommands {
     Start { tid: u32 },
 
     /// Mark the task as completed. Defaults to active task
+    /// 
+    /// --tid defaults to active task
     Complete { tid: Option<u32> },
 
     /// Move a task to a specific status by its ID.
     ///
+    /// --tid defaults to active task
     /// `status` accepts: `new`, `in_progress`, `completed`.
-    Move { tid: u32, status: String },
+    Move { tid: Option<u32>, status: String },
 
     /// Delete a task by its ID.
     Delete { tid: u32 },
 
     /// Edit a task's description and/or priority.
     ///
+    /// --tid defaults to active task
     /// `--priority` accepts: `low`, `medium`, `high`.
     Edit {
-        tid: u32,
+        #[arg(short, long)]
+        tid: Option<u32>,
         #[arg(short, long)]
         desc: Option<String>,
         #[arg(short, long)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -71,9 +71,16 @@ pub enum TaskCommands {
     },
 
     /// List all tasks in the active project, grouped by status.
+    ///
+    /// Pass a status positionally to filter: `new`, `in-progress`, `completed`.
+    /// Use `--pending` / `-p` to show only incomplete tasks (new + in-progress).
     Ls {
-        #[arg(short, long)]
+        /// Filter by status: new, in-progress, completed
         status: Option<String>,
+
+        /// Show only incomplete tasks (new + in-progress)
+        #[arg(short, long, conflicts_with = "status")]
+        pending: bool,
     },
 
     /// Set a task as the active task by its ID.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -79,10 +79,10 @@ pub enum TaskCommands {
     /// Set a task as the active task by its ID.
     ///
     /// Also transitions the task status to `in_progress`.
-    Set { tid: u32 },
+    Start { tid: u32 },
 
-    /// Mark the active task as completed.
-    Completed,
+    /// Mark the task as completed. Defaults to active task
+    Complete { tid: Option<u32> },
 
     /// Move a task to a specific status by its ID.
     ///

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -4,7 +4,7 @@
 //! workspace and project models. Each function handles one family of subcommands.
 
 use crate::cli::{ProjectCommands, TaskCommands};
-use crate::models::{Priority, Project, Status};
+use crate::models::{Project, Status};
 use crate::workspace::Workspace;
 
 /// Execute a `project` subcommand against the given workspace.
@@ -51,20 +51,19 @@ pub fn exec_project_cmd(command: ProjectCommands, workspace: &mut Workspace) -> 
 /// Returns `Err` if the task ID does not exist, the status/priority string is
 /// invalid, or there is no active task when one is required.
 pub fn tid_or_active(project: &Project, tid: Option<u32>) -> Result<u32, String> {
-        tid.or(project.active_task_id)
-        .ok_or("No task selected. Provide a task ID or set an active task with `rtodo task set <id>`.".into())
-    }
-
+    tid.or(project.active_task_id).ok_or(
+        "No task selected. Provide a task ID or set an active task with `rtodo task set <id>`."
+            .into(),
+    )
+}
 
 pub fn exec_task_cmd(command: TaskCommands, project: &mut Project) -> Result<(), String> {
     match command {
         TaskCommands::Ls { status, pending } => {
             let statuses: Option<Vec<Status>> = if pending {
                 Some(vec![Status::New, Status::InProgress])
-            } else if let Some(s) = status {
-                Some(vec![Status::try_from(s.as_str())?])
             } else {
-                None
+                status.map(|s| vec![s])
             };
             println!("{}", project.task_summary(statuses.as_deref()));
         }
@@ -73,7 +72,6 @@ pub fn exec_task_cmd(command: TaskCommands, project: &mut Project) -> Result<(),
             priority,
             parent,
         } => {
-            let priority = Priority::try_from(priority.as_str())?;
             let task = project.add_task(desc, priority, parent)?;
             println!("Task added successfully\n{task}");
         }
@@ -90,7 +88,6 @@ pub fn exec_task_cmd(command: TaskCommands, project: &mut Project) -> Result<(),
             println!("Completed!: {task}");
         }
         TaskCommands::Move { tid, status } => {
-            let status = Status::try_from(status.as_str())?;
             let tid = tid_or_active(project, tid)?;
             if status == Status::Completed && project.has_incomplete_subtasks(tid) {
                 return Err("Task has incomplete subtasks. Complete them first.".into());
@@ -108,9 +105,6 @@ pub fn exec_task_cmd(command: TaskCommands, project: &mut Project) -> Result<(),
             priority,
         } => {
             let tid = tid_or_active(project, tid)?;
-            let priority = priority
-                .map(|p| Priority::try_from(p.as_str()))
-                .transpose()?;
             let task = project.edit_task(tid, desc, priority)?;
             println!("Updated task: {task}");
         }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -58,9 +58,15 @@ pub fn tid_or_active(project: &Project, tid: Option<u32>) -> Result<u32, String>
 
 pub fn exec_task_cmd(command: TaskCommands, project: &mut Project) -> Result<(), String> {
     match command {
-        TaskCommands::Ls { status } => {
-            let status = status.map(|s| Status::try_from(s.as_str())).transpose()?;
-            println!("{}", project.task_summary(status));
+        TaskCommands::Ls { status, pending } => {
+            let statuses: Option<Vec<Status>> = if pending {
+                Some(vec![Status::New, Status::InProgress])
+            } else if let Some(s) = status {
+                Some(vec![Status::try_from(s.as_str())?])
+            } else {
+                None
+            };
+            println!("{}", project.task_summary(statuses.as_deref()));
         }
         TaskCommands::Add {
             desc,

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -65,18 +65,18 @@ pub fn exec_task_cmd(command: TaskCommands, project: &mut Project) -> Result<(),
             let task = project.add_task(desc, priority, parent)?;
             println!("Task added successfully\n{task}");
         }
-        TaskCommands::Set { tid } => {
+        TaskCommands::Start { tid } => {
             let task = project.set_active_task(tid)?;
             println!("Active task: {task}");
         }
-        TaskCommands::Completed => {
-            let id = project.active_task_id.ok_or(
-                "No active task. Use `rtodo task set <id>` or `rtodo task move <id> <status>` instead.",
+        TaskCommands::Complete { tid } => {
+            let id = tid.or(project.active_task_id).ok_or(
+                "No task selected. Provide a task ID or set an active task with `rtodo task set <id>`.",
             )?;
             if project.has_incomplete_subtasks(id) {
                 return Err("Task has incomplete subtasks. Complete them first.".into());
             }
-            let task = project.active_task_completed()?;
+            let task = project.move_task(id, Status::Completed)?;
             println!("Completed!: {task}");
         }
         TaskCommands::Move { tid, status } => {

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -50,6 +50,12 @@ pub fn exec_project_cmd(command: ProjectCommands, workspace: &mut Workspace) -> 
 /// # Errors
 /// Returns `Err` if the task ID does not exist, the status/priority string is
 /// invalid, or there is no active task when one is required.
+pub fn tid_or_active(project: &Project, tid: Option<u32>) -> Result<u32, String> {
+        tid.or(project.active_task_id)
+        .ok_or("No task selected. Provide a task ID or set an active task with `rtodo task set <id>`.".into())
+    }
+
+
 pub fn exec_task_cmd(command: TaskCommands, project: &mut Project) -> Result<(), String> {
     match command {
         TaskCommands::Ls { status } => {
@@ -70,17 +76,16 @@ pub fn exec_task_cmd(command: TaskCommands, project: &mut Project) -> Result<(),
             println!("Active task: {task}");
         }
         TaskCommands::Complete { tid } => {
-            let id = tid.or(project.active_task_id).ok_or(
-                "No task selected. Provide a task ID or set an active task with `rtodo task set <id>`.",
-            )?;
-            if project.has_incomplete_subtasks(id) {
+            let tid = tid_or_active(project, tid)?;
+            if project.has_incomplete_subtasks(tid) {
                 return Err("Task has incomplete subtasks. Complete them first.".into());
             }
-            let task = project.move_task(id, Status::Completed)?;
+            let task = project.move_task(tid, Status::Completed)?;
             println!("Completed!: {task}");
         }
         TaskCommands::Move { tid, status } => {
             let status = Status::try_from(status.as_str())?;
+            let tid = tid_or_active(project, tid)?;
             if status == Status::Completed && project.has_incomplete_subtasks(tid) {
                 return Err("Task has incomplete subtasks. Complete them first.".into());
             }
@@ -96,6 +101,7 @@ pub fn exec_task_cmd(command: TaskCommands, project: &mut Project) -> Result<(),
             desc,
             priority,
         } => {
+            let tid = tid_or_active(project, tid)?;
             let priority = priority
                 .map(|p| Priority::try_from(p.as_str()))
                 .transpose()?;

--- a/src/models.rs
+++ b/src/models.rs
@@ -178,6 +178,11 @@ impl Project {
         description: Option<String>,
         priority: Option<Priority>,
     ) -> Result<&Task, String> {
+
+        if description.is_none() && priority.is_none() {
+            return Err(format!("No changes requested for task #{id}. Please provide a new description or priority."));
+        }
+
         let idx = self
             .find_task(id)
             .ok_or_else(|| format!("Task {id} not found."))?;

--- a/src/models.rs
+++ b/src/models.rs
@@ -178,9 +178,10 @@ impl Project {
         description: Option<String>,
         priority: Option<Priority>,
     ) -> Result<&Task, String> {
-
         if description.is_none() && priority.is_none() {
-            return Err(format!("No changes requested for task #{id}. Please provide a new description or priority."));
+            return Err(format!(
+                "No changes requested for task #{id}. Please provide a new description or priority."
+            ));
         }
 
         let idx = self
@@ -214,6 +215,7 @@ impl Project {
     pub fn task_summary(&self, filter: Option<&[Status]>) -> String {
         let mut out = String::new();
 
+        let is_filtered = filter.is_some();
         let statuses: &[Status] = filter.unwrap_or(ALL_STATUSES);
 
         for section_status in statuses {
@@ -224,7 +226,7 @@ impl Project {
                 .iter()
                 .filter(|t| t.parent_id.is_none())
                 .filter(|t| {
-                    if filter.is_some() {
+                    if is_filtered {
                         t.status == *section_status
                             || self
                                 .subtasks_of(t.id)
@@ -254,7 +256,7 @@ impl Project {
                         .count();
                     let total = subtasks.len();
                     writeln!(out, "  {t}  ({done}/{total})").unwrap();
-                    let visible: Vec<&&Task> = if filter.is_some() {
+                    let visible: Vec<&&Task> = if is_filtered {
                         subtasks
                             .iter()
                             .filter(|s| s.status == *section_status)
@@ -287,33 +289,15 @@ impl fmt::Display for Project {
 }
 
 /// Lifecycle state of a task.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, clap::ValueEnum)]
 pub enum Status {
     /// Task has been created but work has not started.
     New,
     /// Task is actively being worked on.
+    #[value(name = "in-progress")]
     InProgress,
     /// Task has been finished.
     Completed,
-}
-
-impl TryFrom<&str> for Status {
-    type Error = String;
-
-    /// Parse a status from its string representation.
-    ///
-    /// # Errors
-    /// Returns `Err` if `s` is not one of `new`, `in_progress`, `completed`.
-    fn try_from(s: &str) -> Result<Self, Self::Error> {
-        match s {
-            "completed" => Ok(Status::Completed),
-            "in_progress" | "in-progress" => Ok(Status::InProgress),
-            "new" => Ok(Status::New),
-            _ => Err(format!(
-                "Unknown status \"{s}\". Valid values: new, in-progress, completed."
-            )),
-        }
-    }
 }
 
 impl fmt::Display for Status {
@@ -327,7 +311,7 @@ impl fmt::Display for Status {
 }
 
 /// Importance level of a task.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, clap::ValueEnum)]
 pub enum Priority {
     /// Low importance — tackle after `Medium` and `High` tasks.
     Low,
@@ -335,25 +319,6 @@ pub enum Priority {
     Medium,
     /// High importance — shown with a `!` marker in listings.
     High,
-}
-
-impl TryFrom<&str> for Priority {
-    type Error = String;
-
-    /// Parse a priority from its string representation.
-    ///
-    /// # Errors
-    /// Returns `Err` if `s` is not one of `low`, `medium`, `high`.
-    fn try_from(s: &str) -> Result<Self, Self::Error> {
-        match s {
-            "low" => Ok(Priority::Low),
-            "medium" => Ok(Priority::Medium),
-            "high" => Ok(Priority::High),
-            _ => Err(format!(
-                "Unknown priority \"{s}\". Valid values: low, medium, high."
-            )),
-        }
-    }
 }
 
 impl fmt::Display for Priority {

--- a/src/models.rs
+++ b/src/models.rs
@@ -211,13 +211,10 @@ impl Project {
     /// When `status` is `Some`, a top-level task is included if it matches OR any of
     /// its subtasks match; only matching subtasks are shown. When `None`, top-level
     /// tasks are grouped by their own status and all subtasks are shown beneath them.
-    pub fn task_summary(&self, status: Option<Status>) -> String {
+    pub fn task_summary(&self, filter: Option<&[Status]>) -> String {
         let mut out = String::new();
 
-        let statuses: &[Status] = match &status {
-            Some(s) => std::slice::from_ref(s),
-            None => ALL_STATUSES,
-        };
+        let statuses: &[Status] = filter.unwrap_or(ALL_STATUSES);
 
         for section_status in statuses {
             writeln!(out, "{section_status}").unwrap();
@@ -227,7 +224,7 @@ impl Project {
                 .iter()
                 .filter(|t| t.parent_id.is_none())
                 .filter(|t| {
-                    if status.is_some() {
+                    if filter.is_some() {
                         t.status == *section_status
                             || self
                                 .subtasks_of(t.id)
@@ -257,7 +254,7 @@ impl Project {
                         .count();
                     let total = subtasks.len();
                     writeln!(out, "  {t}  ({done}/{total})").unwrap();
-                    let visible: Vec<&&Task> = if status.is_some() {
+                    let visible: Vec<&&Task> = if filter.is_some() {
                         subtasks
                             .iter()
                             .filter(|s| s.status == *section_status)
@@ -310,10 +307,10 @@ impl TryFrom<&str> for Status {
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         match s {
             "completed" => Ok(Status::Completed),
-            "in_progress" => Ok(Status::InProgress),
+            "in_progress" | "in-progress" => Ok(Status::InProgress),
             "new" => Ok(Status::New),
             _ => Err(format!(
-                "Unknown status \"{s}\". Valid values: new, in_progress, completed."
+                "Unknown status \"{s}\". Valid values: new, in-progress, completed."
             )),
         }
     }


### PR DESCRIPTION
## Summary

- Add positional status arg to `task ls` — `rtodo task ls new` replaces `--status new`
- Add `--pending` / `-p` flag to show only incomplete tasks (`new` + `in-progress`)
- `Status` and `Priority` now derive `clap::ValueEnum` — clap parses and validates these directly, removing all manual `TryFrom<&str>` dispatch code
- `in-progress` accepted as CLI-facing name for `InProgress` (hyphen, standard CLI convention)

## What changed

- `src/cli.rs` — positional `status: Option<Status>`, `--pending: bool`, typed `Priority`/`Status` args across `add`, `move`, `edit`
- `src/models.rs` — `clap::ValueEnum` on both enums, `TryFrom<&str>` removed, `task_summary` takes `Option<&[Status]>` with named `is_filtered` bool
- `src/dispatch.rs` — no more string parsing; dispatch works with typed values end-to-end

## Test plan

- [ ] `rtodo task ls` — all tasks, all statuses
- [ ] `rtodo task ls new` — only new tasks
- [ ] `rtodo task ls in-progress` — only in-progress tasks
- [ ] `rtodo task ls --pending` / `-p` — new + in-progress, two headers
- [ ] `rtodo task ls new --pending` — clap conflict error
- [ ] `rtodo task ls badstatus` — clap validation error with possible values listed
- [ ] `cargo test` — all pass
- [ ] `cargo clippy` — no warnings