### PR TITLE
Redesign CLI output with owo-colors and view structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +179,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +210,12 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -253,6 +279,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+dependencies = [
+ "supports-color",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +311,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "clap",
+ "owo-colors",
  "serde",
  "serde_json",
 ]
@@ -340,6 +376,16 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "supports-color"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ba6faf2ca7ee42fdd458f4347ae0a9bd6bcc445ad7cb57ad82b383f18870d6f"
+dependencies = [
+ "atty",
+ "is_ci",
+]
 
 [[package]]
 name = "syn"
@@ -408,6 +454,28 @@ checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 chrono = { version = "0.4.44", features = ["serde"] }
 clap = { version = "4.6.0", features = ["derive"] }
+owo-colors = { version = "3", features = ["supports-colors"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -6,6 +6,7 @@
 use crate::cli::{ProjectCommands, TaskCommands};
 use crate::models::{Project, Status};
 use crate::workspace::Workspace;
+use crate::{style, ui};
 
 /// Execute a `project` subcommand against the given workspace.
 ///
@@ -17,29 +18,41 @@ use crate::workspace::Workspace;
 pub fn exec_project_cmd(command: ProjectCommands, workspace: &mut Workspace) -> Result<(), String> {
     match command {
         ProjectCommands::Add { name } => {
-            workspace.add_project(name);
+            let p = workspace.add_project(name);
+            println!("  {} {}", style::action_green("added"), p);
         }
         ProjectCommands::Ls => {
-            println!("{}", workspace);
+            print!("{}", ui::ProjectListView::new(workspace));
         }
         ProjectCommands::Set { pid } => {
             let p = workspace.set_active_project(pid)?;
-            println!("Active project set to '{}'", p);
+            println!("  {} {}", style::action_cyan("active"), p);
         }
         ProjectCommands::UnSet => {
             workspace.unset_active_project();
-            println!("Active project unset");
+            println!("  {} no active project", style::action_red("unset"));
         }
         ProjectCommands::Delete { pid } => {
             let p = workspace.delete_project(pid)?;
-            println!("{p} have been deleted")
+            println!("  {} {}", style::action_red("removed"), p);
         }
         ProjectCommands::Edit { pid, name } => {
             let p = workspace.edit_project(pid, name)?;
-            println!("{p}")
+            println!("  {} {}", style::action_green("updated"), p);
         }
     };
     Ok(())
+}
+
+/// Resolve an explicit task ID or fall back to the active task.
+///
+/// # Errors
+/// Returns `Err` if both `tid` and the active task are `None`.
+pub fn tid_or_active(project: &Project, tid: Option<u32>) -> Result<u32, String> {
+    tid.or(project.active_task_id).ok_or(
+        "No task selected. Provide a task ID or set an active task with `rtodo task start <id>`."
+            .into(),
+    )
 }
 
 /// Execute a `task` subcommand against the active project.
@@ -50,13 +63,6 @@ pub fn exec_project_cmd(command: ProjectCommands, workspace: &mut Workspace) -> 
 /// # Errors
 /// Returns `Err` if the task ID does not exist, the status/priority string is
 /// invalid, or there is no active task when one is required.
-pub fn tid_or_active(project: &Project, tid: Option<u32>) -> Result<u32, String> {
-    tid.or(project.active_task_id).ok_or(
-        "No task selected. Provide a task ID or set an active task with `rtodo task set <id>`."
-            .into(),
-    )
-}
-
 pub fn exec_task_cmd(command: TaskCommands, project: &mut Project) -> Result<(), String> {
     match command {
         TaskCommands::Ls { status, pending } => {
@@ -65,7 +71,7 @@ pub fn exec_task_cmd(command: TaskCommands, project: &mut Project) -> Result<(),
             } else {
                 status.map(|s| vec![s])
             };
-            println!("{}", project.task_summary(statuses.as_deref()));
+            print!("{}", ui::TaskSummaryView::new(project, statuses.as_deref()));
         }
         TaskCommands::Add {
             desc,
@@ -73,11 +79,11 @@ pub fn exec_task_cmd(command: TaskCommands, project: &mut Project) -> Result<(),
             parent,
         } => {
             let task = project.add_task(desc, priority, parent)?;
-            println!("Task added successfully\n{task}");
+            println!("  {} {}", style::action_green("added"), style::fmt_task_action(task));
         }
         TaskCommands::Start { tid } => {
             let task = project.set_active_task(tid)?;
-            println!("Active task: {task}");
+            println!("  {} {}", style::action_cyan("started"), style::fmt_task_action(task));
         }
         TaskCommands::Complete { tid } => {
             let tid = tid_or_active(project, tid)?;
@@ -85,7 +91,7 @@ pub fn exec_task_cmd(command: TaskCommands, project: &mut Project) -> Result<(),
                 return Err("Task has incomplete subtasks. Complete them first.".into());
             }
             let task = project.move_task(tid, Status::Completed)?;
-            println!("Completed!: {task}");
+            println!("  {} {}", style::action_green("done"), style::fmt_task_action(task));
         }
         TaskCommands::Move { tid, status } => {
             let tid = tid_or_active(project, tid)?;
@@ -93,11 +99,11 @@ pub fn exec_task_cmd(command: TaskCommands, project: &mut Project) -> Result<(),
                 return Err("Task has incomplete subtasks. Complete them first.".into());
             }
             let task = project.move_task(tid, status)?;
-            println!("Task moved to {}: {}", task.status, task);
+            println!("  {} {}", style::action_green("moved"), style::fmt_task_action(task));
         }
         TaskCommands::Delete { tid } => {
             let task = project.delete_task(tid)?;
-            println!("Deleted task: {task}");
+            println!("  {} {}", style::action_red("removed"), style::fmt_task_action(&task));
         }
         TaskCommands::Edit {
             tid,
@@ -106,7 +112,7 @@ pub fn exec_task_cmd(command: TaskCommands, project: &mut Project) -> Result<(),
         } => {
             let tid = tid_or_active(project, tid)?;
             let task = project.edit_task(tid, desc, priority)?;
-            println!("Updated task: {task}");
+            println!("  {} {}", style::action_green("updated"), style::fmt_task_action(task));
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,4 +16,6 @@
 pub mod cli;
 pub mod dispatch;
 pub mod models;
+pub mod style;
+pub mod ui;
 pub mod workspace;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@
 //! or [`exec_task_cmd`] in [`dispatch`]. Workspace state is loaded before
 //! each command and persisted afterward.
 
+use std::io::IsTerminal;
+
 use clap::Parser;
 use rtodo::cli::{CLI, Commands};
 use rtodo::dispatch::{exec_project_cmd, exec_task_cmd};
@@ -33,6 +35,12 @@ fn save_workspace(workspace: &Workspace) -> Result<(), String> {
 /// # Errors
 /// Returns `Err` with a user-facing message on any failure.
 fn run() -> Result<(), String> {
+    // Disable ANSI color codes when stdout is not a TTY (e.g. piped to a file).
+    // `IsTerminal` is a stable trait since Rust 1.70.
+    if !std::io::stdout().is_terminal() {
+        owo_colors::set_override(false);
+    }
+
     let cli = CLI::parse();
 
     match cli.command {
@@ -50,7 +58,7 @@ fn run() -> Result<(), String> {
                 .active_project()
                 .ok_or("No active project. Run `rtodo project set <id>` to set one.")?;
             exec_task_cmd(command, project)?;
-            // this could be improve to only save the project for performance.
+            // this could be improved to only save the project for performance.
             save_workspace(&workspace)?;
         }
     };
@@ -59,7 +67,7 @@ fn run() -> Result<(), String> {
 
 fn main() {
     if let Err(msg) = run() {
-        eprintln!("{}", msg);
+        eprintln!("  {} {}", rtodo::style::error_prefix(), msg);
         std::process::exit(1);
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -10,9 +10,10 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::cmp::Reverse;
 use std::fmt;
-use std::fmt::Write;
 const CREATED_AT_FORMAT: &str = "%Y-%m-%d";
-const ALL_STATUSES: &[Status] = &[Status::InProgress, Status::New, Status::Completed];
+/// All status variants in display order (in-progress → new → completed).
+/// Exposed so [`crate::ui`] can iterate them without duplicating the ordering.
+pub const ALL_STATUSES: &[Status] = &[Status::InProgress, Status::New, Status::Completed];
 
 /// A named project that contains a list of tasks.
 #[derive(Debug, Serialize, Deserialize)]
@@ -207,72 +208,6 @@ impl Project {
         filtered_tasks
     }
 
-    /// Build a formatted string listing tasks grouped by status, with subtasks indented.
-    ///
-    /// When `status` is `Some`, a top-level task is included if it matches OR any of
-    /// its subtasks match; only matching subtasks are shown. When `None`, top-level
-    /// tasks are grouped by their own status and all subtasks are shown beneath them.
-    pub fn task_summary(&self, filter: Option<&[Status]>) -> String {
-        let mut out = String::new();
-
-        let is_filtered = filter.is_some();
-        let statuses: &[Status] = filter.unwrap_or(ALL_STATUSES);
-
-        for section_status in statuses {
-            writeln!(out, "{section_status}").unwrap();
-
-            let mut top_level: Vec<&Task> = self
-                .tasks
-                .iter()
-                .filter(|t| t.parent_id.is_none())
-                .filter(|t| {
-                    if is_filtered {
-                        t.status == *section_status
-                            || self
-                                .subtasks_of(t.id)
-                                .iter()
-                                .any(|s| s.status == *section_status)
-                    } else {
-                        t.status == *section_status
-                    }
-                })
-                .collect();
-
-            top_level.sort_by_key(|t| Reverse(&t.priority));
-
-            if top_level.is_empty() {
-                writeln!(out, "  (none)").unwrap();
-                continue;
-            }
-
-            for t in top_level {
-                let subtasks = self.subtasks_of(t.id);
-                if subtasks.is_empty() {
-                    writeln!(out, "  {t}").unwrap();
-                } else {
-                    let done = subtasks
-                        .iter()
-                        .filter(|s| s.status == Status::Completed)
-                        .count();
-                    let total = subtasks.len();
-                    writeln!(out, "  {t}  ({done}/{total})").unwrap();
-                    let visible: Vec<&&Task> = if is_filtered {
-                        subtasks
-                            .iter()
-                            .filter(|s| s.status == *section_status)
-                            .collect()
-                    } else {
-                        subtasks.iter().collect()
-                    };
-                    for sub in visible {
-                        writeln!(out, "      {sub}").unwrap();
-                    }
-                }
-            }
-        }
-
-        out
-    }
 }
 
 impl fmt::Display for Project {

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,0 +1,233 @@
+//! Terminal styling helpers for `rtodo`.
+//!
+//! All functions produce strings that either contain ANSI escape codes (when
+//! writing to a real TTY) or plain text (when piped / redirected).
+//!
+//! ## How TTY detection works
+//!
+//! [`owo_colors`] has two kinds of color APIs:
+//!
+//! - **Direct**: `.red()`, `.bold()`, … — always emit ANSI codes, no TTY check.
+//! - **Guarded**: `.if_supports_color(stream, |v| v.style(...))` — checks whether
+//!   `stream` is a TTY (via the `supports-colors` feature) and emits codes only
+//!   when it is.
+//!
+//! We use the guarded form everywhere via [`owo_colors::Style`], which combines
+//! multiple attributes into one owned value — avoiding the temporary-borrow
+//! lifetime error you'd get from chaining `.green().bold()` inside a closure.
+//!
+//! ## Color semantics
+//!
+//! | Color  | Meaning                                           |
+//! |--------|---------------------------------------------------|
+//! | Green  | Success / creation / completion                   |
+//! | Cyan   | Active / focus state                              |
+//! | Red    | Destructive operations, high priority             |
+//! | Yellow | In-progress / warning                             |
+//! | Blue   | New / informational                               |
+//! | Dim    | Low-signal metadata (IDs, dates, separators)      |
+
+use chrono::{DateTime, Utc};
+use owo_colors::{OwoColorize, Stream, Style};
+
+use crate::models::{Priority, Status, Task};
+
+const DATE_FORMAT: &str = "%Y-%m-%d";
+const STDOUT: Stream = Stream::Stdout;
+const STDERR: Stream = Stream::Stderr;
+
+// ── Action prefix helpers ────────────────────────────────────────────────────
+
+/// Bold green prefix, right-padded to 8 chars. Use for creation/success operations.
+///
+/// Padding is applied *before* color so ANSI bytes don't skew the field width.
+pub fn action_green(label: &str) -> String {
+    let padded = format!("{:<8}", label);
+    format!(
+        "{}",
+        padded.if_supports_color(STDOUT, |v| v.style(Style::new().green().bold()))
+    )
+}
+
+/// Bold cyan prefix, right-padded to 8 chars. Use for focus / active operations.
+pub fn action_cyan(label: &str) -> String {
+    let padded = format!("{:<8}", label);
+    format!(
+        "{}",
+        padded.if_supports_color(STDOUT, |v| v.style(Style::new().cyan().bold()))
+    )
+}
+
+/// Bold red prefix, right-padded to 8 chars. Use for destructive operations.
+pub fn action_red(label: &str) -> String {
+    let padded = format!("{:<8}", label);
+    format!(
+        "{}",
+        padded.if_supports_color(STDOUT, |v| v.style(Style::new().red().bold()))
+    )
+}
+
+/// Bold red prefix for stderr. Use for error messages.
+pub fn error_prefix() -> String {
+    format!(
+        "{}",
+        "error:".if_supports_color(STDERR, |v| v.style(Style::new().red().bold()))
+    )
+}
+
+// ── Field formatters ─────────────────────────────────────────────────────────
+
+/// Dimmed `[n]` ID bracket.
+pub fn fmt_id(id: u32) -> String {
+    format!(
+        "{}",
+        format!("[{}]", id).if_supports_color(STDOUT, |v| v.style(Style::new().dimmed()))
+    )
+}
+
+/// Dimmed date string (`YYYY-MM-DD`).
+pub fn fmt_date(dt: &DateTime<Utc>) -> String {
+    let s = dt.format(DATE_FORMAT).to_string();
+    format!("{}", s.if_supports_color(STDOUT, |v| v.style(Style::new().dimmed())))
+}
+
+/// Two-char priority symbol with semantic color.
+///
+/// - `!!` bold red  — high
+/// -  ` ·` white    — medium
+/// -  ` ·` dim      — low
+pub fn fmt_priority_symbol(priority: &Priority) -> String {
+    match priority {
+        Priority::High => format!(
+            "{}",
+            "!!".if_supports_color(STDOUT, |v| v.style(Style::new().red().bold()))
+        ),
+        Priority::Medium => format!(
+            " {}",
+            "·".if_supports_color(STDOUT, |v| v.style(Style::new().white()))
+        ),
+        Priority::Low => format!(
+            " {}",
+            "·".if_supports_color(STDOUT, |v| v.style(Style::new().dimmed()))
+        ),
+    }
+}
+
+/// Priority as a full colored text label. Used in single-task action lines.
+pub fn fmt_priority_label(priority: &Priority) -> String {
+    match priority {
+        Priority::High => format!(
+            "{}",
+            "high".if_supports_color(STDOUT, |v| v.style(Style::new().red().bold()))
+        ),
+        Priority::Medium => "medium".to_string(),
+        Priority::Low => format!(
+            "{}",
+            "low".if_supports_color(STDOUT, |v| v.style(Style::new().dimmed()))
+        ),
+    }
+}
+
+// ── List row formatters ──────────────────────────────────────────────────────
+
+/// Bold, colored section header with a dim separator line.
+///
+/// ```text
+/// ● In Progress ──────────────────────────────────────────────
+/// ● New ──────────────────────────────────────────────────────
+/// ✓ Completed ────────────────────────────────────────────────
+/// ```
+pub fn fmt_status_header(status: &Status) -> String {
+    let (symbol, label) = match status {
+        Status::InProgress => (
+            "●",
+            format!(
+                "{}",
+                "In Progress"
+                    .if_supports_color(STDOUT, |v| v.style(Style::new().yellow().bold()))
+            ),
+        ),
+        Status::New => (
+            "●",
+            format!(
+                "{}",
+                "New".if_supports_color(STDOUT, |v| v.style(Style::new().blue().bold()))
+            ),
+        ),
+        Status::Completed => (
+            "✓",
+            format!(
+                "{}",
+                "Completed"
+                    .if_supports_color(STDOUT, |v| v.style(Style::new().green().bold()))
+            ),
+        ),
+    };
+    // Fixed-length separator — avoids needing to know terminal width.
+    let sep = format!(
+        "{}",
+        "─".repeat(44).if_supports_color(STDOUT, |v| v.style(Style::new().dimmed()))
+    );
+    format!("{symbol} {label} {sep}")
+}
+
+/// Format a top-level task row for the task list.
+///
+/// Columns: indent · dim ID · active/priority marker · description
+/// (padded to `desc_width`) · priority symbol · dim date
+///
+/// ```text
+///   [1] * Fix bug in module           !!  2026-04-13
+///   [0]   Write documentation          ·  2026-04-13
+/// ```
+pub fn fmt_task_line(task: &Task, is_active: bool, desc_width: usize) -> String {
+    let id = fmt_id(task.id);
+    let marker = if is_active {
+        format!(
+            "{}",
+            "*".if_supports_color(STDOUT, |v| v.style(Style::new().cyan().bold()))
+        )
+    } else if task.priority == Priority::High {
+        format!(
+            "{}",
+            "!".if_supports_color(STDOUT, |v| v.style(Style::new().red().bold()))
+        )
+    } else {
+        " ".to_string()
+    };
+    // Pad plain string before any color — format width is measured correctly.
+    let desc = format!("{:<width$}", task.description, width = desc_width);
+    let prio = fmt_priority_symbol(&task.priority);
+    let date = fmt_date(&task.created_at);
+    format!("  {} {} {}  {}  {}", id, marker, desc, prio, date)
+}
+
+/// Format a subtask row for the task list, indented with a dim `↳` arrow.
+///
+/// ```text
+///       ↳ [3]   Subtask detail          ·  2026-04-13
+/// ```
+pub fn fmt_sub_line(task: &Task, desc_width: usize) -> String {
+    let id = fmt_id(task.id);
+    let desc = format!("{:<width$}", task.description, width = desc_width);
+    let prio = fmt_priority_symbol(&task.priority);
+    let date = fmt_date(&task.created_at);
+    let arrow = format!(
+        "{}",
+        "↳".if_supports_color(STDOUT, |v| v.style(Style::new().dimmed()))
+    );
+    format!("      {} {} {}  {}  {}", arrow, id, desc, prio, date)
+}
+
+/// Format a task as a compact single-line string for action output
+/// (used after add / start / complete / edit / delete).
+///
+/// ```text
+/// [0] Write documentation   medium   2026-04-13
+/// ```
+pub fn fmt_task_action(task: &Task) -> String {
+    let id = fmt_id(task.id);
+    let prio = fmt_priority_label(&task.priority);
+    let date = fmt_date(&task.created_at);
+    format!("{} {}   {}   {}", id, task.description, prio, date)
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,0 +1,237 @@
+//! Presentation layer for `rtodo`.
+//!
+//! This module owns all terminal-facing formatted output.  The domain types in
+//! [`crate::models`] and [`crate::workspace`] deliberately stay plain — they
+//! expose plain-text `Display` impls suitable for debugging and testing.
+//! Everything visual lives here.
+//!
+//! # Design: View structs + `Display`
+//!
+//! Each "view" is a lightweight struct that borrows the data it needs to render.
+//! Implementing [`std::fmt::Display`] instead of returning `String` gives three
+//! benefits:
+//! 
+use std::cmp::Reverse;
+use std::fmt;
+
+use owo_colors::{OwoColorize, Stream, Style};
+
+use crate::models::{Project, Status, Task, ALL_STATUSES};
+use crate::style;
+use crate::workspace::Workspace;
+
+// ── Task list view ────────────────────────────────────────────────────────────
+
+/// A view over a [`Project`]'s task list, ready for colorized terminal display.
+///
+/// # Example
+/// ```ignore
+/// println!("{}", TaskSummaryView::new(project, None));
+/// println!("{}", TaskSummaryView::new(project, Some(&[Status::New])));
+/// ```
+pub struct TaskSummaryView<'a> {
+    project: &'a Project,
+    filter: Option<&'a [Status]>,
+}
+
+impl<'a> TaskSummaryView<'a> {
+    pub fn new(project: &'a Project, filter: Option<&'a [Status]>) -> Self {
+        Self { project, filter }
+    }
+}
+
+impl fmt::Display for TaskSummaryView<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let is_filtered = self.filter.is_some();
+        let statuses = self.filter.unwrap_or(ALL_STATUSES);
+        let width = task_desc_width(self.project);
+
+        for section_status in statuses {
+            write_section(f, self.project, section_status, is_filtered, width)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Returns the max task description length in the project, used for column alignment.
+/// Subtasks are included so their column aligns with top-level tasks.
+fn task_desc_width(project: &Project) -> usize {
+    project
+        .tasks
+        .iter()
+        .map(|t| t.description.len())
+        .max()
+        .unwrap_or(10)
+        .max(10)
+}
+
+/// Returns top-level tasks that belong in `section_status`, sorted by priority descending.
+///
+/// When `is_filtered`, a parent is included if it matches *or* any of its subtasks match —
+/// so the parent is visible as context even when its own status differs.
+fn top_level_for_section<'a>(
+    project: &'a Project,
+    section_status: &Status,
+    is_filtered: bool,
+) -> Vec<&'a Task> {
+    let mut tasks: Vec<&Task> = project
+        .tasks
+        .iter()
+        .filter(|t| t.parent_id.is_none())
+        .filter(|t| {
+            if is_filtered {
+                t.status == *section_status
+                    || project
+                        .subtasks_of(t.id)
+                        .iter()
+                        .any(|s| s.status == *section_status)
+            } else {
+                t.status == *section_status
+            }
+        })
+        .collect();
+
+    tasks.sort_by_key(|t| Reverse(&t.priority));
+    tasks
+}
+
+/// Writes one status section: header, task rows (or an "(empty)" notice), and a trailing
+/// blank line.
+fn write_section(
+    f: &mut fmt::Formatter<'_>,
+    project: &Project,
+    section_status: &Status,
+    is_filtered: bool,
+    desc_width: usize,
+) -> fmt::Result {
+    writeln!(f, "{}", style::fmt_status_header(section_status))?;
+
+    let top_level = top_level_for_section(project, section_status, is_filtered);
+
+    if top_level.is_empty() {
+        writeln!(f, "  {}", "(empty)".if_supports_color(Stream::Stdout, |v| v.dimmed()))?;
+    } else {
+        for task in top_level {
+            write_task(f, project, task, section_status, is_filtered, desc_width)?;
+        }
+    }
+
+    writeln!(f) // blank line between sections
+}
+
+/// Writes a single task row and, when it has subtasks, the progress badge and subtask rows.
+fn write_task(
+    f: &mut fmt::Formatter<'_>,
+    project: &Project,
+    task: &Task,
+    section_status: &Status,
+    is_filtered: bool,
+    desc_width: usize,
+) -> fmt::Result {
+    let subtasks = project.subtasks_of(task.id);
+    let is_active = Some(task.id) == project.active_task_id;
+    let line = style::fmt_task_line(task, is_active, desc_width);
+
+    if subtasks.is_empty() {
+        return writeln!(f, "{}", line);
+    }
+
+    let done = subtasks
+        .iter()
+        .filter(|s| s.status == Status::Completed)
+        .count();
+    let total = subtasks.len();
+    let badge = format!(
+        "{}",
+        format!("[{done}/{total}]").if_supports_color(Stream::Stdout, |v| v.cyan())
+    );
+    writeln!(f, "{}  {}", line, badge)?;
+
+    write_subtasks(f, subtasks, section_status, is_filtered, desc_width)
+}
+
+/// Writes the subtask rows for a parent, applying the status filter when active.
+fn write_subtasks(
+    f: &mut fmt::Formatter<'_>,
+    subtasks: Vec<&Task>,
+    section_status: &Status,
+    is_filtered: bool,
+    desc_width: usize,
+) -> fmt::Result {
+    let visible: Vec<&Task> = if is_filtered {
+        subtasks
+            .into_iter()
+            .filter(|s| s.status == *section_status)
+            .collect()
+    } else {
+        subtasks
+    };
+
+    for sub in visible {
+        writeln!(f, "{}", style::fmt_sub_line(sub, desc_width))?;
+    }
+
+    Ok(())
+}
+
+// ── Project list view ─────────────────────────────────────────────────────────
+
+/// A view over a [`Workspace`]'s project list, ready for colorized terminal display.
+///
+/// # Example
+/// ```ignore
+/// println!("{}", ProjectListView::new(&workspace));
+/// ```
+pub struct ProjectListView<'a> {
+    workspace: &'a Workspace,
+}
+
+impl<'a> ProjectListView<'a> {
+    pub fn new(workspace: &'a Workspace) -> Self {
+        Self { workspace }
+    }
+}
+
+impl fmt::Display for ProjectListView<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let workspace = self.workspace;
+
+        if workspace.projects.is_empty() {
+            return writeln!(
+                f,
+                "  {}",
+                "No projects yet. Run `rtodo project add <name>` to create one."
+                    .if_supports_color(Stream::Stdout, |v| v.dimmed())
+            );
+        }
+
+        // Align project names in a consistent column.
+        let name_width = workspace
+            .projects
+            .iter()
+            .map(|p| p.name.len())
+            .max()
+            .unwrap_or(10)
+            .max(10);
+
+        for p in &workspace.projects {
+            let id = style::fmt_id(p.id);
+            let name = format!("{:<width$}", p.name, width = name_width);
+            let count = format!("{} tasks", p.task_count());
+            let date = style::fmt_date(&p.created_at);
+            let active = if workspace.active_project_id == Some(p.id) {
+                format!(
+                    "  {}",
+                    "← active"
+                        .if_supports_color(Stream::Stdout, |v| v.style(Style::new().cyan().bold()))
+                )
+            } else {
+                String::new()
+            };
+            writeln!(f, "  {} {}  {}  {}{}", id, name, count, date, active)?;
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
- Introduces `owo-colors` with full TTY detection — piped output is always
  plain text, verified by redirecting to a file and checking for ANSI bytes
- New `src/style.rs` module: semantic color helpers (green = success,
  cyan = active, red = destructive, yellow = in-progress, blue = new, dim =
  metadata) using `Style::new()` builder to sidestep the closure
  temp-borrow lifetime issue that prevents chaining `.green().bold()`
- New `src/ui.rs` module: `TaskSummaryView` and `ProjectListView` implement
  `Display` directly instead of returning `String` — zero allocation, `?`
  error propagation, lifetimes make the borrow relationship explicit.
  `TaskSummaryView::fmt` is decomposed into four focused helpers with a clear
  call tree: `write_section` → `top_level_for_section` + `write_task` →
  `write_subtasks`
- Separates presentation from data: `models.rs` keeps plain-text `Display`
  impls; all colored output lives in `ui.rs` / `style.rs`

## Test plan

- [ ] `cargo test` — all 10 tests pass
- [ ] `cargo clippy` — zero warnings
- [ ] `cargo run -- task ls` — colored grouped list renders in terminal
- [ ] `cargo run -- task ls > /tmp/out.txt && xxd /tmp/out.txt | grep -c 1b` — outputs `0` (no ANSI codes when redirected)
- [ ] `cargo run -- task add "x"` / `start` / `complete` / `delete` / `edit` — each prints a colored action prefix
- [ ] `cargo run -- project ls` — tabular list, active project gets `← active`
- [ ] `cargo run -- project add "x"` — no longer silent; prints `added` confirmation
